### PR TITLE
Refactor carousel and add spacing in home screen

### DIFF
--- a/lib/screens/carousel/popular_courses_carousel.dart
+++ b/lib/screens/carousel/popular_courses_carousel.dart
@@ -1,5 +1,5 @@
+import 'package:e_learning_apps/color/app_colors.dart';
 import 'package:flutter/material.dart';
-import 'package:carousel_slider/carousel_slider.dart';
 import '../course/course_details.dart';
 
 class SimpleCourseCard extends StatelessWidget {
@@ -213,20 +213,20 @@ class PopularCoursesSlider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CarouselSlider.builder(
-      options: CarouselOptions(
-        height: 240.0,
-        enableInfiniteScroll: false,
-        viewportFraction: 0.7,
+    return Container(
+      height: 240.0,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: courses.length,
+        itemBuilder: (context, index) {
+          final course = courses[index];
+          return Container(
+            margin: const EdgeInsets.symmetric(horizontal: 8),
+            width: MediaQuery.of(context).size.width * 0.6,
+            child: SimpleCourseCard(courseData: course),
+          );
+        },
       ),
-      itemCount: courses.length,
-      itemBuilder: (BuildContext context, int index, int realIndex) {
-        final course = courses[index];
-        return Container(
-          margin: const EdgeInsets.symmetric(horizontal: 2.0),
-          child: SimpleCourseCard(courseData: course),
-        );
-      },
     );
   }
 }
@@ -237,7 +237,7 @@ void main() {
       home: Scaffold(
         appBar: AppBar(
           title: const Text('Popular Courses'),
-          backgroundColor: const Color(0xFF0C042E),
+          backgroundColor: AppColors.primaryColor,
         ),
         body: PopularCoursesSlider(),
       ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -78,6 +78,7 @@ class _HomeScreenState extends State<HomeScreen> {
       child: SingleChildScrollView(
         child: Column(
           children: [
+            SizedBox(height: 20),
             buildUserInfo(), // Panggil fungsi buildUserInfo di sini
             SizedBox(height: 20),
             Card(


### PR DESCRIPTION
This pull request refactors the carousel in the home screen and adds spacing between elements. The previous implementation used the `carousel_slider` package, but it has been replaced with a `ListView.builder` wrapped in a `Container` to achieve the desired layout. The height of the container is set to 240.0, and each item in the list has a margin of 8 pixels on the horizontal axis. Additionally, a `SizedBox` with a height of 20 pixels has been added before the `buildUserInfo` function call to create some vertical spacing. This improves the overall user experience and visual appeal of the home screen.

Fixes #1234